### PR TITLE
Ignore projects named with certain suffixes

### DIFF
--- a/AllTargets/HookClasses/Xcode3TargetMembershipDataSource+Hook.m
+++ b/AllTargets/HookClasses/Xcode3TargetMembershipDataSource+Hook.m
@@ -24,7 +24,20 @@
     
     // Run our custom code
     NSMutableArray *wrappedTargets = [self valueForKey:@"wrappedTargets"];
+    NSArray *ignoreSuffixes = @[ @"Test", @"Tests", @"Spec", @"Specs" ];
     for (Xcode3TargetWrapper *wrappedTarget in wrappedTargets) {
+        BOOL __block ignore = NO;
+        [ignoreSuffixes enumerateObjectsUsingBlock:^(NSString * _Nonnull suffix, NSUInteger idx, BOOL * _Nonnull stop) {
+            if ([wrappedTarget.name hasSuffix:suffix]) {
+                ignore = YES;
+            }
+            *stop = ignore;
+        }];
+        
+        if (ignore) {
+            continue;
+        }
+        
         wrappedTarget.selected = YES;
     }
 }

--- a/AllTargets/HookClasses/Xcode3TargetMembershipDataSource+Hook.m
+++ b/AllTargets/HookClasses/Xcode3TargetMembershipDataSource+Hook.m
@@ -26,15 +26,15 @@
     NSMutableArray *wrappedTargets = [self valueForKey:@"wrappedTargets"];
     NSArray *ignoreSuffixes = @[ @"Test", @"Tests", @"Spec", @"Specs" ];
     for (Xcode3TargetWrapper *wrappedTarget in wrappedTargets) {
-        BOOL __block ignore = NO;
+        BOOL __block ignoreTarget = NO;
         [ignoreSuffixes enumerateObjectsUsingBlock:^(NSString * _Nonnull suffix, NSUInteger idx, BOOL * _Nonnull stop) {
             if ([wrappedTarget.name hasSuffix:suffix]) {
-                ignore = YES;
+                ignoreTarget = YES;
             }
-            *stop = ignore;
+            *stop = ignoreTarget;
         }];
         
-        if (ignore) {
+        if (ignoreTarget) {
             continue;
         }
         


### PR DESCRIPTION
Most often, I do not want the Test targets selected. This patch checks the name of each target and if it ends with "Test(s)" or "Spec(s)", then the target is not selected. All other targets are selected.

If there is a better way to check whether a target is a "test" target, please let me know and I can update this PR. Thanks!
